### PR TITLE
[deps] update peerDep for calipers

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "mocha-lcov-reporter": "^1.3.0"
   },
   "peerDependencies": {
-    "calipers": "2.x.x"
+    "calipers": "^2 || ^3"
   }
 }


### PR DESCRIPTION
Updated `peerDependencies` for `calipers` since this package already works with both v2 & v3 and currently trying to use `calipers-jpeg` with `calipers@3` makes NPM complain a lot.